### PR TITLE
SEO-2271 Angular Rotator Missing H1 tag

### DIFF
--- a/angular/Rotator/display-settings.md
+++ b/angular/Rotator/display-settings.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Display settings in Angular rotator control | Syncfusion
-description: Learn more about display settings in Syncfusion Angular rotator control, its elements, and more.
+description: Learn here more about display settings in Syncfusion Angular rotator control, its elements, and more.
 platform: Angular
 control: rotator
 documentation: ug


### PR DESCRIPTION
Hi @ChristoIssac,

Please review the changes for Angular Rotator Missing H1 tag.

Regards,
Yvone.