### PR TITLE
SEO-187452-Angular-Title-too-long/short

### DIFF
--- a/angular/Listview/Overview.md
+++ b/angular/Listview/Overview.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Overview
-description: Overview
+title: Overview in Angular Listview | Syncfusio
+description: Learn here about overview support in Syncfusion Essential Angular Listview control, its elements and more details.
 platform: Angular
 control: ListView
 documentation: ug
 ---
 
-## Overview
+# Overview in Angular Listview control
 
 The Essential Angular ListView component builds interactive ListView interface. This control allows you to select an item from a list-like interface and display a set of data items in different layouts or views. Lists are used for displaying data, data navigation, result lists, and data entry.
 

--- a/angular/Listview/Overview.md
+++ b/angular/Listview/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Overview of Angular ListView | Syncfusion
-description: Learn here about overview support in Syncfusion Essential Angular ListView control, its elements and more details.
+description: Learn here about overview of Syncfusion Essential Angular ListView control, its elements and more details.
 platform: angular
 control: ListView
 documentation: ug

--- a/angular/Listview/Overview.md
+++ b/angular/Listview/Overview.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Overview of Angular Listview | Syncfusion
-description: Learn here about overview support in Syncfusion Essential Angular Listview control, its elements and more details.
+title: Overview of Angular ListView | Syncfusion
+description: Learn here about overview support in Syncfusion Essential Angular ListView control, its elements and more details.
 platform: Angular
 control: ListView
 documentation: ug
 ---
 
-# Overview of Angular Listview control
+# Overview of Angular ListView Control
 
 The Essential Angular ListView component builds interactive ListView interface. This control allows you to select an item from a list-like interface and display a set of data items in different layouts or views. Lists are used for displaying data, data navigation, result lists, and data entry.
 

--- a/angular/Listview/Overview.md
+++ b/angular/Listview/Overview.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Overview in Angular Listview | Syncfusio
+title: Overview of Angular Listview | Syncfusio
 description: Learn here about overview support in Syncfusion Essential Angular Listview control, its elements and more details.
 platform: Angular
 control: ListView
 documentation: ug
 ---
 
-# Overview in Angular Listview control
+# Overview of Angular Listview control
 
 The Essential Angular ListView component builds interactive ListView interface. This control allows you to select an item from a list-like interface and display a set of data items in different layouts or views. Lists are used for displaying data, data navigation, result lists, and data entry.
 

--- a/angular/Listview/Overview.md
+++ b/angular/Listview/Overview.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Overview of Angular Listview | Syncfusio
+title: Overview of Angular Listview | Syncfusion
 description: Learn here about overview support in Syncfusion Essential Angular Listview control, its elements and more details.
 platform: Angular
 control: ListView

--- a/angular/Listview/Overview.md
+++ b/angular/Listview/Overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: Overview of Angular ListView | Syncfusion
 description: Learn here about overview support in Syncfusion Essential Angular ListView control, its elements and more details.
-platform: Angular
+platform: angular
 control: ListView
 documentation: ug
 ---

--- a/angular/Listview/Overview.md
+++ b/angular/Listview/Overview.md
@@ -11,7 +11,7 @@ documentation: ug
 
 The Essential Angular ListView component builds interactive ListView interface. This control allows you to select an item from a list-like interface and display a set of data items in different layouts or views. Lists are used for displaying data, data navigation, result lists, and data entry.
 
-### Key Features
+## Key Features
 
 AJAX Load: Loads AJAX content in the ListView content.
 


### PR DESCRIPTION
Hi @Yvone-Atieno,

|Title|Description|
|--|--|
|Category|Title too long/short link |
|Hotfix PR|https://github.com/syncfusion-content/angular-docs/pull/376|
|Task||
|Content Ticket||
|UX Ticket||

|Changes made|Reason for changes|
|--|--|
|Modify meta elements|For meta alignment with proper character count|
|Removed # tag|To have h1 in the page for proper alignment|

Regards,
Edith.