### PR TITLE
SEO-202684-Angular-Charts-Stripline-docs-title-too-short

### DIFF
--- a/angular/Chart/Striplines.md
+++ b/angular/Chart/Striplines.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Chart Striplines
+title: Horizontal or Vertical Chart Stripline in Angular | Syncfusion
 description: Learn how to add horizontal or vertical lines in Chart.                                                  
 platform: Angular
 control: Chart


### PR DESCRIPTION
@MallikaRK 

|Title|Description|
|--|--|
|Task Category|Bing report-Title too short|
|Content Task Link/Mail Screenshot| NA|
|UX task| NA|
|Hotfix PR|https://github.com/syncfusion-content/angular-docs/pull/398 |
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/203480/|
|Excel/SharePoint link|https://syncfusion-my.sharepoint.com/:x:/p/asha_bhaskaran/ES1KWjpJG9ZJjf0MlCDpqRoBUWD97iW9-gKahgUAUz_hdg?wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1749814865502&web=1|

|Changes made|Reason for changes|
|--|--|
|Meta Title |  To get the right Character Count in Title btw 20-70 |     



Regards,
Hillary