### PR TITLE
SEO-202684-Angular-datepicker-docs-title-too-short

### DIFF
--- a/angular/DatePicker/How-To.md
+++ b/angular/DatePicker/How-To.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: How-to
+title: customization of range selection in Angular DatePicker | Syncfusion
 description: How-to section
 platform: Angular
 control: DatePicker


### PR DESCRIPTION
@MallikaRK 

|Title|Description|
|--|--|
|Task Category|Bing report-Title too short|
|Content Task Link/Mail Screenshot| NA|
|UX task| NA|
|Hotfix PR|https://github.com/syncfusion-content/angular-docs/pull/400|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/203480/|
|Excel/SharePoint link|https://syncfusion-my.sharepoint.com/:x:/p/asha_bhaskaran/ES1KWjpJG9ZJjf0MlCDpqRoBUWD97iW9-gKahgUAUz_hdg?wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1749814865502&web=1 |

|Changes made|Reason for changes|
|--|--|
|Meta Title |  To get the right meta Title count btw 20-70 |     



Regards,
Hillary