### PR TITLE
SEO-204026-Image-Alt-Missing-Hotfix

### DIFF
--- a/angular/Grid/Toolbar.md
+++ b/angular/Grid/Toolbar.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Toolbar with Grid widget for Syncfusion Essential JS
-description: How to enable toolbar and its actions.
+description: Check out and learn here all about how to enable the toolbar and its actions of Syncfusion Angular Gantt and much more details.
 platform: angular
 control: Grid
 documentation: ug
@@ -80,7 +80,7 @@ Search text in records</td></tr>
 {% endhighlight %}
 
 
-![](Toolbar_images/Toolbar_img1.png)
+![Default toolbar items.](Toolbar_images/Toolbar_img1.png)
 
 
 I> [`editSettings.allowAdding`](https://help.syncfusion.com/api/angular/ejgrid#members:editsettings-allowadding "allowAdding"), [`editSettings.allowEditing`](https://help.syncfusion.com/api/angular/ejgrid#members:editsettings-allowediting "allowEditing") and [`editSettings.allowDeleting`](https://help.syncfusion.com/api/angular/ejgrid#members:editsettings-allowdeleting "allowdeleting") need to be enabled for add, delete, edit, save & cancel in [`toolbarItems`](https://help.syncfusion.com/api/angular/ejgrid#members:toolbarsettings-toolbaritems "toolbaritems"). [`allowSearching`](https://help.syncfusion.com/api/angular/ejgrid#members:allowsearching "allowsearching")` to be enabled while adding Search in toolbar to perform search action.
@@ -138,6 +138,6 @@ Custom toolbar is used to create your own toolbar items in toolbar. It can add b
 
 {% endhighlight %}
 
-![](Toolbar_images/Toolbar_img2.jpeg)
+![Custom toolbar.](Toolbar_images/Toolbar_img2.jpeg)
 
 

--- a/angular/Kanban/Getting-Started.md
+++ b/angular/Kanban/Getting-Started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting started with Kanban component	
-description: Rendering a Kanban control
+description: Check out and learn here all about Rendering of Syncfusion Angular Kanban control and much more details.
 platform: Angular
 control: kanban
 documentation: ug
@@ -246,7 +246,7 @@ export class KanbanComponent {
 
 {% endhighlight %}
 
-![](Getting_Started_images/Getting_Started_img1.png)
+![Control Initialization.](Getting_Started_images/Getting_Started_img1.png)
 
 ## Mapping Values
 
@@ -289,7 +289,7 @@ export class KanbanComponent {
 
 {% endhighlight %}
 
-![](Getting_Started_images/Getting_Started_img2.png)
+![Mapping field.](Getting_Started_images/Getting_Started_img2.png)
 
 ## Enable Swimlane
 
@@ -327,7 +327,7 @@ export class KanbanComponent {
 
 {% endhighlight %}
 
-![](Getting_Started_images/Getting_Started_img3.png)
+![Swimlane.](Getting_Started_images/Getting_Started_img3.png)
 
 ## Adding Filters
 
@@ -371,4 +371,4 @@ export class KanbanComponent {
 
 {% endhighlight %}
 
-![](Getting_Started_images/Getting_Started_img4.png)
+![Filters.](Getting_Started_images/Getting_Started_img4.png)

--- a/angular/Menu/Context-Menu.md
+++ b/angular/Menu/Context-Menu.md
@@ -80,7 +80,7 @@ Add the following code in menu.component.css file.
 
 The following screen shot displays the output of the above code.
 
-![](Context-Menu_images/Context-Menu_img1.png) 
+![the output of the above code.](Context-Menu_images/Context-Menu_img1.png) 
 
 You can hide and show the context menu using the following methods.
 

--- a/angular/RichTextEditor/Working-with-Lists.md
+++ b/angular/RichTextEditor/Working-with-Lists.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Working with Lists operation in RichTextEditor widget
-description: Working with Lists customization for RichTextEditor widget
+description: Check out and learn here all about working with lists customization for RichTextEditor widget and much more details. 
 platform: Angular
 control: RichTextEditor
 documentation: ug
@@ -102,7 +102,7 @@ export class RTEComponent {
 
 {% endhighlight %}
 
-![](WorkingwithLists_images/ordered.png)
+![customOrderedList.](WorkingwithLists_images/ordered.png)
 
 ### Insert a customUnorderedList
 
@@ -161,4 +161,4 @@ export class RTEComponent {
 
 {% endhighlight %}
 
-![](WorkingwithLists_images/unordered.png)
+![customUnorderedList.](WorkingwithLists_images/unordered.png)


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204026/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B425BC1DA-899F-43C9-83EC-59BDC2E6D2D3%7D&file=Bing%20Issues%20-%20SEO.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha