### PR TITLE
SEO-204825-Angular-Description-Too-Short-Hotfix

### DIFF
--- a/angular/GettingStarted/getting-started-angular-cli.md
+++ b/angular/GettingStarted/getting-started-angular-cli.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Getting Started with Angular CLI | Syncfusion
-description: Overview of Syncfusion Essential Angular
+description: Check out and learn here all about overview of Syncfusion Essential Syncfusion Angular and much more details.
 platform: Angular
 control: Introduction
 documentation: ug


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Description too short|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Meta description| Meta description was too short. SEO rule says it should be 100+ characters, so I changed it.|


Regards, 
Asha