### PR TITLE
SEO-204825-Image-Alt-Missing-Angular-Hotfix

### DIFF
--- a/angular/Accordion/Getting-Started.md
+++ b/angular/Accordion/Getting-Started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started for Angular Accordion
-description: Getting Started for Angular Accordion
+description: Check out and learn here all about getting started with Angular Accordion in Syncfusion and much more details.
 platform: Angular
 control: Accordion
 documentation: Ug
@@ -16,7 +16,7 @@ This section encompasses the details on how you can configure the **Accordion** 
 
 The following screenshot illustrates you the usage of **Accordion** control in listing the controls under the Essential Studio products. 
 
-![](Getting-Started-images/Getting-Started_img1.png) 
+![Configure Accordion in Angular.](Getting-Started-images/Getting-Started_img1.png) 
 
 The usage of **Accordion** control is described in the following sections.
 
@@ -146,7 +146,7 @@ Create the Accordion control as follows.
 
 You can execute the above code example to display the Accordion control with simple control list.
 
-![](Getting-Started-images/Getting-Started_img2.png) 
+![Create a Simple Accordion in Angular.](Getting-Started-images/Getting-Started_img2.png) 
 
 You can customize the Accordion control using various properties. The Accordion control properties and its default values are described in the following section.
 
@@ -257,7 +257,7 @@ You can also open all the panels during initialization using the **selectedItems
 
 **Accordion** control with **enableMultipleOpen** property is illustrated in the following screen shot.
 
-![](Getting-Started-images/Getting-Started_img3.png) 
+![Configure Multiple Open in Accordion.](Getting-Started-images/Getting-Started_img3.png) 
 
 ### Setting rounded corner
 
@@ -343,7 +343,7 @@ N> showRoundedCorner property is False by default.
 
 The following screenshot illustrates the **Accordion** control with rounded corners.
 
-![](Getting-Started-images/Getting-Started_img4.png) 
+![Setting rounded corner in Accordion.](Getting-Started-images/Getting-Started_img4.png) 
 
 ## Customize Icon
 
@@ -434,5 +434,5 @@ You can set the Up or Down arrow icon to **Accordion** header, by adding **e-arr
 
 The following screenshot illustrates the customization of **selectedHeader** and **header** of the **Accordion** control.
 
-![](Getting-Started-images/Getting-Started_img5.png) 
+![Customize Icon.](Getting-Started-images/Getting-Started_img5.png) 
 

--- a/angular/Diagram/Getting-Started.md
+++ b/angular/Diagram/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Getting Started for Angular Diagram
-description: Getting Started for Angular Diagram
+description: Check out and learn here all about Getting Started for Angular Diagram in Syncfusion and much more details.
 platform: Angular
 control: Diagram
 documentation: ug
@@ -71,7 +71,7 @@ import {EJ_DIAGRAM_COMPONENTS} from 'ej/diagram.component';
 
 This creates an empty diagram
 
-![](Getting-Started-images/Getting-Started_img1.png)
+![Initialize Diagram in Angular.](Getting-Started-images/Getting-Started_img1.png)
 
 ### Initialize Nodes and Connectors
 
@@ -120,7 +120,7 @@ export class DiagramComponent {
 	
 {% endhighlight %}
 	
-![](Getting-Started-images/Getting-Started_img2.png)
+![Initialize Nodes and Connectors in Diagram.](Getting-Started-images/Getting-Started_img2.png)
 
 ### Business object (Employee information)
 
@@ -187,4 +187,4 @@ export class DefaultComponent {
 
 * The Employee details are displayed in the Diagram as follows.
 
-![](Getting-Started_images/Getting-Started_img3.png)
+![Map data source in Angular.](Getting-Started-images/Getting-Started_img3.png)

--- a/angular/Gantt/Task-Scheduling-modes.md
+++ b/angular/Gantt/Task-Scheduling-modes.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Task-scheduling-modes
-description: Task scheduling modes
+description: Check out and learn here all about task scheduling modes for Angular Gantt in Syncfusion and much more details.
 platform: Angular
 control: Gantt
 documentation: ug
@@ -103,4 +103,4 @@ export class AppComponent {
 
 The following screen shot depicts a project with custom scheduling mode, where both automatic and manual scheduling modes are mapped to the tasks.
 
-![](Task-Scheduling-modes_images/Task-Scheduling-modes_img1.png)
+![Manually Scheduled tasks in Task Scheduling Modes.](Task-Scheduling-modes_images/Task-Scheduling-modes_img1.png)


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
|Ticket/Task link| [https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204388|](https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/)
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha