### PR TITLE
SEO-202684-Bing-report-Meta-description-too-short

### DIFF
--- a/angular/Chart/Getting-started.md
+++ b/angular/Chart/Getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started for Chart
-description: How to create a chart, add series, enable tooltip and other functionalities
+description: Checkout and learn here all about how to create a chart, add series, enable tooltip and other functionalities in Syncfusion Angular Chart
 platform: Angular
 control: chart
 documentation: ug


### PR DESCRIPTION
@MallikaRK 

|Title|Description|
|--|--|
|Task Category|Bing report-Meta description too short|
|Content Task Link/Mail Screenshot| NA|
|UX task| NA|
|Hotfix PR|https://github.com/syncfusion-content/angular-docs/pull/397 |
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/202684|
|Excel/SharePoint link|https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B80B7E540-D71F-4A38-8DF0-BC6FDF9BA10C%7D&file=Meta%20descriptions%20on%20many%20of%20your%20pages%20are%20too%20short..xlsx&action=default&mobileredirect=true&ovuser=77f1fe12-b049-4919-8c50-9fb41e5bb63b%2Casha.bhaskaran%40syncfusion.com&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yNTA1MDQwMTYyMiIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D |

|Changes made|Reason for changes|
|--|--|
|Adding character in the description count |  To get the right description character count from 100-160 |     



Regards,
Hillary