### PR TITLE
SEO-202684-Angular-Chart-Description too short

### DIFF
--- a/angular/Chart/Getting-started.md
+++ b/angular/Chart/Getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started for Chart
-description: How to create a chart, add series, enable tooltip and other functionalities
+description: Checkout and learn here all about how to create a chart, add series, enable tooltip and other functionalities in Syncfusion Angular Chart.
 platform: Angular
 control: chart
 documentation: ug


### PR DESCRIPTION
@MallikaRK 

|Title|Description|
|--|--|
|Task Category|Bing report-Meta description too short|
|Content Task Link/Mail Screenshot| NA|
|UX task| NA|
|Hotfix PR|https://github.com/syncfusion-content/angular-docs/pull/413 |
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/202684|
|Excel/SharePoint link| |

|Changes made|Reason for changes|
|--|--|
|Adding character in the description count |  To get the right description character count from 100-160 |     



Regards,
Hillary