### PR TITLE
SEO-205214-Image-Alt-Missing-Angular-Hotfix

### DIFF
--- a/angular/Gantt/Task-Scheduling-modes.md
+++ b/angular/Gantt/Task-Scheduling-modes.md
@@ -103,4 +103,4 @@ export class AppComponent {
 
 The following screen shot depicts a project with custom scheduling mode, where both automatic and manual scheduling modes are mapped to the tasks.
 
-![](Task-Scheduling-modes_images/Task-Scheduling-modes_img1.png)
+![task scheduling modes in custom angular gantt.](Task-Scheduling-modes_images/Task-Scheduling-modes_img1.png)

--- a/angular/Kanban/Getting-Started.md
+++ b/angular/Kanban/Getting-Started.md
@@ -289,7 +289,7 @@ export class KanbanComponent {
 
 {% endhighlight %}
 
-![](Getting_Started_images/Getting_Started_img2.png)
+![mapping values in kanban.](Getting_Started_images/Getting_Started_img2.png)
 
 ## Enable Swimlane
 
@@ -327,7 +327,7 @@ export class KanbanComponent {
 
 {% endhighlight %}
 
-![](Getting_Started_images/Getting_Started_img3.png)
+![enable swimlane in angular kanban.](Getting_Started_images/Getting_Started_img3.png)
 
 ## Adding Filters
 
@@ -371,4 +371,4 @@ export class KanbanComponent {
 
 {% endhighlight %}
 
-![](Getting_Started_images/Getting_Started_img4.png)
+![adding filters in angular kanban.](Getting_Started_images/Getting_Started_img4.png)

--- a/angular/RichTextEditor/Working-with-Lists.md
+++ b/angular/RichTextEditor/Working-with-Lists.md
@@ -102,7 +102,7 @@ export class RTEComponent {
 
 {% endhighlight %}
 
-![](WorkingwithLists_images/ordered.png)
+![inset a custom ordered list in angular rich text editor.](WorkingwithLists_images/ordered.png)
 
 ### Insert a customUnorderedList
 
@@ -161,4 +161,4 @@ export class RTEComponent {
 
 {% endhighlight %}
 
-![](WorkingwithLists_images/unordered.png)
+![insert a custom unordered list in angular rich text ecitor.](WorkingwithLists_images/unordered.png)


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/205214/|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B13A50D72-C3C5-4635-90F2-E36DE3A8B07C%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|




Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha